### PR TITLE
切换textalk/websocket 版本以删除对于psr/http-message的依赖

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - [星火大模型 API 免费套餐](https://xinghuo.xfyun.cn/sparkapi?scr=price)
 - [官方文档](https://www.xfyun.cn/doc/spark/Web.html)
+- [原项目地址](https://github.com/jiannei/spark-ai "spark-ai")
 
 ## 安装
 

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
     "authors": [
         {
             "name": "jiannei",
-            "email": "longjian.huang@foxmail.com"
+            "email": "longjian.comhuang@foxmail.com"
         }
     ],
     "require": {
         "php": "^7.0 || ^8.0",
-        "textalk/websocket": "^1.6",
-        "ext-json": "*"
+        "ext-json": "*",
+        "textalk/websocket": "1.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
         {
             "name": "jiannei",
             "email": "longjian.comhuang@foxmail.com"
+        },
+        {
+            "name": "Nic",
+            "email": "niclalalla@163.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jiannei/spark-ai",
+    "name": "niclalalla/spark-ai",
     "description": "讯飞星火大模型 Api",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
textalk/websocket(v1.6+) 依赖于psr/http-message(v1.0+)，这会和laravel8+ 产生依赖冲突，因此为了减少其他情况下的依赖冲突，引入更低的版本以用来减少依赖